### PR TITLE
refactoring: use CMake object targets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,8 +18,6 @@ jobs:
         build_type: ["Debug", "Release"]
     env:
       DISPLAY: ":99"
-      CONAN_USERNAME: "gamedev"
-      CONAN_CHANNEL: "stable"
       CONAN_REVISIONS_ENABLED: "1"
     steps:
       - uses: actions/checkout@v2
@@ -63,8 +61,6 @@ jobs:
           - { name: "Visual Studio 16", compiler: "Visual Studio", version: 16 }
         build_type: ["Debug", "Release"]
     env:
-      CONAN_USERNAME: "gamedev"
-      CONAN_CHANNEL: "stable"
       CONAN_REVISIONS_ENABLED: "1"
     steps:
       - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 
 project(
     glfwcxx
-    VERSION 1.3.0
+    VERSION 1.3.1
     LANGUAGES CXX)
 
 include(BuildSettings)

--- a/cmake/ProjectUtils.cmake
+++ b/cmake/ProjectUtils.cmake
@@ -1,55 +1,87 @@
 function(add_glfwcxx_target)
     set(options)
-    set(oneValueArgs NAME)
-    set(multiValueArgs SOURCES STUB_SOURCES EXTRA_PRIVATE_LIBS EXTRA_PRIVATE_STUB_LIBS)
+    set(oneValueArgs GLFWCXX_TARGET_NAME)
+    set(multiValueArgs TARGET_SOURCES PRIVATE_DEPENDENCY_TARGETS)
     cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    set(CURRENT_TARGET ${ARG_NAME})
-    add_library(${CURRENT_TARGET} STATIC ${ARG_SOURCES})
-    add_library(glfwcxx::${CURRENT_TARGET} ALIAS ${CURRENT_TARGET})
-    target_include_directories(
-        ${CURRENT_TARGET} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/${ARG_NAME}>)
-    target_link_libraries(${CURRENT_TARGET} PRIVATE $<BUILD_INTERFACE:glfw::glfw>)
-    if(DEFINED ARG_EXTRA_PRIVATE_LIBS)
-        foreach(EXTRA_LIB IN LISTS ARG_EXTRA_PRIVATE_LIBS)
-            target_link_libraries(${CURRENT_TARGET} PRIVATE $<BUILD_INTERFACE:${EXTRA_LIB}>)
-        endforeach()
-    endif()
+    set(GLFWCXX_TARGET ${ARG_GLFWCXX_TARGET_NAME})
+    set(GLFWCXX_OBJECT_TARGET ${GLFWCXX_TARGET}-object)
 
-    set(CURRENT_STUB_TARGET ${CURRENT_TARGET}-stub)
-    add_library(${CURRENT_STUB_TARGET} STATIC ${ARG_SOURCES} ${ARG_STUB_SOURCES})
-    add_library(glfwcxx::${CURRENT_STUB_TARGET} ALIAS ${CURRENT_STUB_TARGET})
+    add_library(${GLFWCXX_OBJECT_TARGET} OBJECT ${ARG_TARGET_SOURCES})
+    target_sources(${GLFWCXX_OBJECT_TARGET} INTERFACE ${ARG_TARGET_SOURCES})
     target_include_directories(
-        ${CURRENT_STUB_TARGET}
-        PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/${ARG_NAME}>
+        ${GLFWCXX_OBJECT_TARGET}
+        PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/${GLFWCXX_TARGET}>)
+    foreach(DEPENDENCY_TARGET IN LISTS ARG_PRIVATE_DEPENDENCY_TARGETS)
+        if(NOT TARGET ${DEPENDENCY_TARGET})
+            message(FATAL_ERROR "${DEPENDENCY_TARGET} is not a real target")
+        endif()
+        get_target_property(DEPENDENCY_HEADERS ${DEPENDENCY_TARGET} INTERFACE_INCLUDE_DIRECTORIES)
+        target_include_directories(${GLFWCXX_OBJECT_TARGET}
+                                   PRIVATE $<BUILD_INTERFACE:${DEPENDENCY_HEADERS}>)
+    endforeach()
+
+    add_library(${GLFWCXX_TARGET} STATIC $<TARGET_OBJECTS:${GLFWCXX_OBJECT_TARGET}>)
+    target_include_directories(
+        ${GLFWCXX_TARGET}
+        INTERFACE $<TARGET_PROPERTY:${GLFWCXX_OBJECT_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
+    foreach(DEPENDENCY_TARGET IN LISTS ARG_PRIVATE_DEPENDENCY_TARGETS)
+        target_link_libraries(${GLFWCXX_TARGET} PRIVATE $<BUILD_INTERFACE:${DEPENDENCY_TARGET}>)
+    endforeach()
+
+    add_library(glfwcxx::${GLFWCXX_TARGET} ALIAS ${GLFWCXX_TARGET})
+endfunction()
+
+function(add_glfwcxx_stub_target)
+    set(options)
+    set(oneValueArgs GLFWCXX_TARGET_NAME)
+    set(multiValueArgs TARGET_SOURCES PRIVATE_DEPENDENCY_TARGETS)
+    cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    set(GLFWCXX_TARGET ${ARG_GLFWCXX_TARGET_NAME})
+    set(GLFWCXX_OBJECT_TARGET ${GLFWCXX_TARGET}-object)
+    set(GLFWCXX_STUB_TARGET ${GLFWCXX_TARGET}-stub)
+
+    add_library(${GLFWCXX_STUB_TARGET} STATIC
+                ${ARG_TARGET_SOURCES} $<TARGET_PROPERTY:${GLFWCXX_OBJECT_TARGET},INTERFACE_SOURCES>)
+    target_include_directories(
+        ${GLFWCXX_STUB_TARGET}
+        PUBLIC $<TARGET_PROPERTY:${GLFWCXX_OBJECT_TARGET},INTERFACE_INCLUDE_DIRECTORIES>
                $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/stub>)
-    target_link_libraries(${CURRENT_STUB_TARGET} PRIVATE $<BUILD_INTERFACE:glfwstub>)
-    if(DEFINED ARG_EXTRA_PRIVATE_STUB_LIBS)
-        foreach(EXTRA_LIB IN LISTS ARG_EXTRA_PRIVATE_STUB_LIBS)
-            target_link_libraries(${CURRENT_STUB_TARGET} PRIVATE $<BUILD_INTERFACE:${EXTRA_LIB}>)
-        endforeach()
-    endif()
+    foreach(DEPENDENCY_TARGET IN LISTS ARG_PRIVATE_DEPENDENCY_TARGETS)
+        target_link_libraries(${GLFWCXX_STUB_TARGET}
+                              PRIVATE $<BUILD_INTERFACE:${DEPENDENCY_TARGET}>)
+    endforeach()
+
+    add_library(glfwcxx::${GLFWCXX_STUB_TARGET} ALIAS ${GLFWCXX_STUB_TARGET})
 endfunction()
 
 function(install_glfwcxx_target)
     set(options)
-    set(oneValueArgs NAME)
+    set(oneValueArgs GLFWCXX_TARGET_NAME)
     set(multiValueArgs)
     cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    set(CURRENT_TARGET ${ARG_NAME})
+    set(GLFWCXX_TARGET ${ARG_GLFWCXX_TARGET_NAME})
     install(
-        TARGETS ${CURRENT_TARGET}
+        TARGETS ${GLFWCXX_TARGET}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         INCLUDES
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-    install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/${ARG_NAME}/glfwcxx
+    install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/${GLFWCXX_TARGET}/glfwcxx
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endfunction()
 
-    set(CURRENT_STUB_TARGET ${CURRENT_TARGET}-stub)
+function(install_glfwcxx_stub_target)
+    set(options)
+    set(oneValueArgs GLFWCXX_TARGET_NAME)
+    set(multiValueArgs)
+    cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    set(GLFWCXX_STUB_TARGET ${ARG_GLFWCXX_TARGET_NAME}-stub)
     install(
-        TARGETS ${CURRENT_STUB_TARGET}
+        TARGETS ${GLFWCXX_STUB_TARGET}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         INCLUDES

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,6 +12,8 @@ class GLFWCXX(ConanFile):
     description = "C++17 wrapper of GLFW"
     url = "git@github.com:EugeneKuznetsov/glfwcxx.git"
     scm = {"type": "git", "url": "auto", "revision": "auto"}
+    default_user = "gamedev"
+    default_channel = "stable"
     generators = "cmake_find_package"
     settings = "os", "compiler", "arch", "build_type"
     tool_requires = "cmake/[>3.20.x]", "ninja/[^1.11.x]", "gtest/[~1.11.x]"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(GNUInstallDirs)
 include(ProjectUtils)
 
+add_subdirectory(glfwstub)
 add_subdirectory(glfwcxx/common)
 add_subdirectory(glfwcxx/core)
 add_subdirectory(glfwcxx/window)
-add_subdirectory(glfwstub)

--- a/src/glfwcxx/common/CMakeLists.txt
+++ b/src/glfwcxx/common/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(TARGET_NAME common)
-set(SOURCES Common.cpp)
-set(STUB_SOURCES CommonStub.cpp)
 
-add_glfwcxx_target(NAME ${TARGET_NAME} SOURCES ${SOURCES} STUB_SOURCES ${STUB_SOURCES})
-install_glfwcxx_target(NAME ${TARGET_NAME})
+add_glfwcxx_target(GLFWCXX_TARGET_NAME ${TARGET_NAME} TARGET_SOURCES Common.cpp
+                   PRIVATE_DEPENDENCY_TARGETS glfw::glfw)
+add_glfwcxx_stub_target(GLFWCXX_TARGET_NAME ${TARGET_NAME} TARGET_SOURCES CommonStub.cpp
+                        PRIVATE_DEPENDENCY_TARGETS glfwstub)
+
+install_glfwcxx_target(GLFWCXX_TARGET_NAME ${TARGET_NAME})
+install_glfwcxx_stub_target(GLFWCXX_TARGET_NAME ${TARGET_NAME})

--- a/src/glfwcxx/core/CMakeLists.txt
+++ b/src/glfwcxx/core/CMakeLists.txt
@@ -1,16 +1,22 @@
 set(TARGET_NAME core)
-set(SOURCES Core.cpp CoreInitHints.cpp)
-set(STUB_SOURCES CoreStub.cpp)
 
 add_glfwcxx_target(
-    NAME
+    GLFWCXX_TARGET_NAME
     ${TARGET_NAME}
-    SOURCES
-    ${SOURCES}
-    STUB_SOURCES
-    ${STUB_SOURCES}
-    EXTRA_PRIVATE_LIBS
-    glfwcxx::common
-    EXTRA_PRIVATE_STUB_LIBS
+    TARGET_SOURCES
+    Core.cpp
+    CoreInitHints.cpp
+    PRIVATE_DEPENDENCY_TARGETS
+    glfw::glfw
+    glfwcxx::common)
+add_glfwcxx_stub_target(
+    GLFWCXX_TARGET_NAME
+    ${TARGET_NAME}
+    TARGET_SOURCES
+    CoreStub.cpp
+    PRIVATE_DEPENDENCY_TARGETS
+    glfwstub
     glfwcxx::common-stub)
-install_glfwcxx_target(NAME ${TARGET_NAME})
+
+install_glfwcxx_target(GLFWCXX_TARGET_NAME ${TARGET_NAME})
+install_glfwcxx_stub_target(GLFWCXX_TARGET_NAME ${TARGET_NAME})

--- a/src/glfwcxx/window/CMakeLists.txt
+++ b/src/glfwcxx/window/CMakeLists.txt
@@ -1,16 +1,22 @@
 set(TARGET_NAME window)
-set(SOURCES Window.cpp WindowHints.cpp)
-set(STUB_SOURCES WindowStub.cpp)
 
 add_glfwcxx_target(
-    NAME
+    GLFWCXX_TARGET_NAME
     ${TARGET_NAME}
-    SOURCES
-    ${SOURCES}
-    STUB_SOURCES
-    ${STUB_SOURCES}
-    EXTRA_PRIVATE_LIBS
-    glfwcxx::common
-    EXTRA_PRIVATE_STUB_LIBS
+    TARGET_SOURCES
+    Window.cpp
+    WindowHints.cpp
+    PRIVATE_DEPENDENCY_TARGETS
+    glfw::glfw
+    glfwcxx::common)
+add_glfwcxx_stub_target(
+    GLFWCXX_TARGET_NAME
+    ${TARGET_NAME}
+    TARGET_SOURCES
+    WindowStub.cpp
+    PRIVATE_DEPENDENCY_TARGETS
+    glfwstub
     glfwcxx::common-stub)
-install_glfwcxx_target(NAME ${TARGET_NAME})
+
+install_glfwcxx_target(GLFWCXX_TARGET_NAME ${TARGET_NAME})
+install_glfwcxx_stub_target(GLFWCXX_TARGET_NAME ${TARGET_NAME})


### PR DESCRIPTION
compile time remains the same... anyway CMake code looks more readable and reusable

closes #6